### PR TITLE
docs: suggest adding ORM SQL code to template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -14,3 +14,4 @@
 
 <!-- Be creative! This is useful even for backend PRs. -->
 
+<!-- If your PR includes ORM migrations, please add the generated SQL code -->


### PR DESCRIPTION
# More Details

We've had a lot of PRs that include ORM migrations recently, which are quite painful to review - Django migrations, SQLAlchemy/alembic...

This PR includes a reminder on the PR template to add the generated SQL code so it's easier to review.

