### PR TITLE
ci: add github action to label PR based on conventional commits

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,35 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+
+    - title: Exciting New Features 🎉
+      labels:
+        - feature
+        - enhancement
+
+    - title: Fixes 🔧
+      labels:
+        - fix
+        - bug
+
+    - title: Documentation 📝
+      labels:
+        - documentation
+
+    - title: Dependencies 🤖
+      labels:
+        - dependencies
+
+    - title: Other Changes ➕
+      labels:
+        - feature-flag cleanup
+        - refactor
+        - chore
+        - test
+        - "*"

--- a/.github/workflows/conventional-label.yaml
+++ b/.github/workflows/conventional-label.yaml
@@ -1,0 +1,13 @@
+on:
+  pull_request_target:
+    types: [ opened, edited ]
+
+name: conventional-release-labels
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: bcoe/conventional-release-labels@v1
+        with:
+          type_labels: '{"feat": "feature", "feat!": "breaking-change", "fix": "fix", "fix!": "breaking-change", "fix": "bug", "docs": "documentation", "ci": "ci", "chore": "chore", "chore!": "breaking-change", "refactor": "refactor", "refactor!": "breaking-change", "test": "test", "build": "dependencies", "build!": "dependencies"}'


### PR DESCRIPTION
# More Details

The idea is to use the Gihub Actions to label our PRs based on conventional commits. That will enable us to customize the GitHub Release Notes generation and better organize (or exclude) our release notes

# Screenshots, SQL, etc.

The idea is to create categories in our Release Notes and avoid too much noise from dependabot bumps
<img width="504" alt="image" src="https://github.com/draytechnologies/.github/assets/9361568/ef1e1c83-e00c-4504-bcb2-ae039516906d">
